### PR TITLE
178 update prop metadata

### DIFF
--- a/item-and-prop-generation/src/metadata/item_metadata.json
+++ b/item-and-prop-generation/src/metadata/item_metadata.json
@@ -2,26 +2,26 @@
     "Potions and Elixirs": [
         {
             "name": "Healing Potion",
-            "desc": "A vial of rejuvenating liquid that swiftly restores a portion of the drinker's vitality, providing a precious lifeline in dire situations.",
+            "desc": "A vial filled with a shimmering, revitalizing liquid.",
             "rarity": "common",
-            "properties": "Restores a moderate amount of health instantly."
+            "properties": "When consumed, it swiftly restores a portion of the drinker's vitality, providing a precious lifeline in dire situations."
         },
         {
             "name": "Potion of Invisibility",
             "desc": "A vial containing a shimmering potion that bestows temporary invisibility, enabling stealthy maneuvers and evasion.",
             "rarity": "uncommon",
-            "properties": "Grants temporary invisibility, allowing the user to move undetected."
-        
+            "properties": "When consumed, it bestows temporary invisibility upon the user, enabling stealthy maneuvers and evasion."
+
         },
         {
             "name": "Potion of Fire Resistance",
-            "desc": "A potion that grants temporary protection against the searing heat of flames, bolstering the drinker's resilience to fire-based attacks.",
+            "desc": "A vial containing a sparkling, transparent potion.",
             "rarity": "uncommon",
-            "properties": "Provides temporary resistance to fire damage and immunity to fire-based conditions."
+            "properties": "When consumed, it grants temporary resistance to fire damage and immunity to fire-based conditions."
         },
         {
             "name": "Potion of Strength",
-            "desc": "A concoction that temporarily enhances the imbiber's physical might, empowering them with increased brawn and fortitude.",
+            "desc": "A vial containing transparent liquid.",
             "rarity": "rare",
             "properties": "Temporarily increases the user's physical strength and carrying capacity."
         }
@@ -29,65 +29,65 @@
     "Scrolls": [
         {
             "name": "Scroll of Identify",
-            "desc": "An inscribed parchment that imparts the ability to discern the arcane nature of items, unraveling their hidden potential.",
+            "desc": "An intricately inscribed parchment bearing arcane symbols.",
             "rarity": "common",
-            "properties": "Allows the reader to identify magical properties of items."
+            "properties": "When read, it imparts the ability to discern the arcane nature of items, unraveling their hidden potential or magical properties."
         },
         {
             "name": "Scroll of Mage Armor",
-            "desc": "A scroll containing an incantation that conjures a protective ethereal barrier around the reader, enhancing their defense.",
+            "desc": "A scroll adorned with shimmering runes.",
             "rarity": "uncommon",
-            "properties": "Conjures a shimmering barrier that enhances the reader's defense against attacks."
+            "properties": "When read, it conjures a shimmering barrier that enhances the reader's defense against attacks."
         },
         {
             "name": "Scroll of Dimension Door",
-            "desc": "An ancient script detailing a mystical transportation spell, enabling the reader to traverse short distances instantaneously.",
+            "desc": "An ancient script etched onto velum.",
             "rarity": "rare",
-            "properties": "Allows the reader to instantly teleport to a nearby location."
+            "properties": "When the incantation is spoken, it activates a mystical transportation spell, allowing the reader to traverse short distances instantaneously."
         }
     ],
     "Weapons and Armor": [
         {
             "name": "Longsword",
-            "desc": "A versatile and well-balanced one-handed weapon, favored by adventurers for its adaptability in close combat.",
+            "desc": "A versatile and well-balanced one-handed weapon.",
             "rarity": "common",
-            "properties": "A well-balanced one-handed sword suitable for various combat situations."
+            "properties": "A well-balanced one-handed sword suitable for various combat situations and, favored by adventurers for its adaptability in close combat."
         },
         {
             "name": "Shortbow",
-            "desc": "A ranged weapon capable of launching projectiles with precision, providing a means to engage foes from a distance.",
+            "desc": "A ranged weapon capable of launching projectiles with precision.",
             "rarity": "uncommon",
             "properties": "Allows the user to shoot arrows with accuracy and range."
         },
         {
             "name": "Leather Armor",
-            "desc": "Supple and lightweight armor that offers moderate protection without hindering agility.",
+            "desc": "A supple and lightweight armor. Ideal for adventurers who prioritize mobility.",
             "rarity": "common",
-            "properties": "Lightweight and flexible armor that provides moderate protection."
+            "properties": "It provides moderate protection without hindering agility."
         },
         {
             "name": "Chain Mail",
-            "desc": "A sturdy suit of interlocking metal rings, providing solid defense while maintaining mobility.",
+            "desc": "A sturdy suit of interlocking metal rings.",
             "rarity": "uncommon",
-            "properties": "Durable armor made of interlocking metal rings that offers good defense and mobility."
+            "properties": "Durable armor made of interlocking metal rings that offers good defense and mobility, making it a favorite among warriors."
         }
     ],
     "Magical Items": [
         {
             "name": "Ring of Protection",
-            "desc": "A magical ring that envelops the wearer in a subtle shield, augmenting their armor class and fortifying their defenses.",
+            "desc": "A magical ring adorned with intricate enchantments.",
             "rarity": "uncommon",
-            "properties": "Creates an invisible shield around the wearer, enhancing their armor class and resistance to attacks."
+            "properties": "Creates an invisible shield around the wearer, enhancing their armor class and fortifying their defenses."
         },
         {
             "name": "Amulet of Health",
-            "desc": "An enchanted amulet that bestows improved vitality upon the wearer, bolstering their constitution and hit points.",
+            "desc": "An enchanted amulet radiating a soothing aura.",
             "rarity": "rare",
             "properties": "Enhances the wearer's health, granting additional hit points and vitality."
         },
         {
             "name": "Cloak of Elvenkind",
-            "desc": "A finely crafted cloak that grants the wearer an uncanny ability to blend into shadows and move with remarkable stealth.",
+            "desc": "A finely crafted cloak adorned with elven motifs.",
             "rarity": "uncommon",
             "properties": "Allows the wearer to blend into shadows and move silently, enhancing their stealth capabilities."
         }
@@ -95,19 +95,19 @@
     "Traps and Tools": [
         {
             "name": "Thieves' Tools",
-            "desc": "A meticulously crafted set of tools essential for adeptly picking locks, disarming traps, and executing stealthy maneuvers.",
+            "desc": "A meticulously crafted set of tools.",
             "rarity": "common",
-            "properties": "Includes a set of tools used for lock-picking, trap-disarming, and other covert activities."
+            "properties": "Includes a set of tools used for adept lock-picking, trap-disarming, and other covert activities."
         },
         {
             "name": "Bear Trap",
-            "desc": "A menacing contraption designed to ensnare unsuspecting creatures, immobilizing them with its powerful jaws.",
+            "desc": "A spring-loaded trap that clamps down on unsuspecting creatures.",
             "rarity": "uncommon",
-            "properties": "A spring-loaded trap that clamps down on creatures, immobilizing them until released."
+            "properties": "Immobilizes the victim until released."
         },
         {
             "name": "Tripwire Alarm",
-            "desc": "A cunningly deployed mechanism triggered by movement, emitting an alerting signal to thwart potential intruders.",
+            "desc": "A cunningly deployed mechanism triggered by movement.",
             "rarity": "uncommon",
             "properties": "Emits an audible alarm when triggered by movement, alerting nearby individuals."
         }
@@ -115,51 +115,39 @@
     "Treasure and Valuables": [
         {
             "name": "Gold Coins",
-            "desc": "Gleaming currency recognized throughout realms, serving as a universal medium for trade and acquisition.",
+            "desc": "Gleaming currency recognized throughout realms.",
             "rarity": "common",
             "properties": "Standard currency used for trade and acquisition of goods and services."
         },
         {
             "name": "Gemstones",
-            "desc": "Precious and alluring gems that hold substantial monetary value, as well as potential applications in magical rituals.",
+            "desc": "Precious and alluring gems that hold substantial monetary value.",
             "rarity": "uncommon",
             "properties": "Valuable gemstones that can be traded or used in magical rituals."
         },
         {
             "name": "Art Objects",
-            "desc": "Elegantly crafted paintings, sculptures, and artistic creations that showcase opulence and artistic prowess, often sought after by collectors.",
+            "desc": "Elegantly crafted paintings, sculptures, and artistic creations.",
             "rarity": "rare",
-            "properties": "Exquisite art pieces that demonstrate craftsmanship and luxury, sought after by collectors."
-        },
-        {
-            "name": "Pouch of Gems",
-            "desc": "A tiny sack containing scattered gems throughout the map, valuable as trade items or components for magical rituals.",
-            "rarity": "uncommon",
-            "properties":"This pouch contains an assortment of various gemstones, each possessing its own unique size, color, and value. While not as rare as some individual gemstones, this collection is still quite valuable. The gems can be used for trade and commerce, where they are highly sought after for their beauty and rarity. Additionally, some spellcasters and alchemists may find these gems useful as components in their magical rituals and experiments."
-        },
-        {
-            "name": "Gem of Seeing",
-            "desc": "A gem that allows truesight out to 120 feet when you peer through the gem.",
-            "rarity": "rare",
-            "properties": "This extraordinary gem possesses three charges of otherworldly energy, which can be harnessed for remarkable insight and vision. By speaking the gem's secret command word and expending a single charge as an action, the wielder can unlock its extraordinary power. For the next ten minutes, those who peer through the gem are bestowed with the gift of truesight. This extraordinary vision extends up to 120 feet, allowing the user to see through illusions, magical disguises, and perceive the true nature of creatures and objects concealed from ordinary sight. The Gem of Seeing is not an infinite well of power. However, it regenerates its magical energy gradually. At each dawn, it regains a random number of expended charges, usually ranging from 1 to 3. This ensures that its wielder can call upon its power again, but not without moments of anticipation and uncertainty."
+            "properties": "They demonstrate craftsmanship and luxury, sought after by collectors."
         }
     ],
     "Key Items": [
         {
             "name": "Ornate Key",
-            "desc": "A finely detailed key designed for a specific lock, granting access to secured areas or revealing hidden chambers.",
+            "desc": "A finely detailed key designed for a specific lock.",
             "rarity": "uncommon",
             "properties": "Unlocks specific locks or reveals concealed passages and compartments."
         },
         {
             "name": "Rune Stone",
-            "desc": "An intricately engraved stone that acts as a catalyst for activating enigmatic portals, bridging distant locations.",
+            "desc": "An intricately engraved stone.",
             "rarity": "rare",
-            "properties": "Activates mysterious portals, allowing instantaneous travel across distances."
+            "properties": "It acts as a catalyst for activating enigmatic portals, allowing instantaneous travel across distances."
         },
         {
             "name": "Puzzle Box",
-            "desc": "An enigmatic container concealing intricate mechanisms, secrets, or vital clues, requiring intellectual finesse to unlock its mysteries.",
+            "desc": "An enigmatic container.",
             "rarity": "uncommon",
             "properties": "Holds complex mechanisms or crucial clues, challenging the mind to unlock its secrets."
         }
@@ -167,19 +155,19 @@
     "Dungeoneering Supplies": [
         {
             "name": "Rope and Grappling Hook",
-            "desc": "Essential tools for navigating treacherous terrain, facilitating climbing, descents, and strategic movement.",
+            "desc": "Essential tools for navigating treacherous terrain.",
             "rarity": "common",
             "properties": "Aids in climbing, rappelling, and traversing difficult terrain during explorations."
         },
         {
             "name": "Lantern",
-            "desc": "A reliable source of illumination that pierces through the darkness, banishing obscurity and revealing hidden passages.",
+            "desc": "A reliable source of illumination.",
             "rarity": "uncommon",
-            "properties": "Provides steady illumination, dispelling darkness and revealing hidden details."
+            "properties": "Dispels darkness and reveals hidden details."
         },
         {
             "name": "Rations",
-            "desc": "Nourishing sustenance vital for sustaining adventurers during perilous journeys and arduous quests.",
+            "desc": "Vital for sustaining adventurers during perilous journeys and arduous quests.",
             "rarity": "common",
             "properties": "Provides nourishment to adventurers, sustaining them during their travels and quests."
         }
@@ -187,112 +175,115 @@
     "Cursed Items": [
         {
             "name": "Cursed Dagger",
-            "desc": "A malevolent blade imbued with a sinister curse, inflicting detrimental effects upon its wielder.",
+            "desc": "A malevolent blade imbued with a sinister curse.",
             "rarity": "rare",
-            "properties": "Carries a malevolent curse that harms the wielder with each strike."
+            "properties": "Inflicts detrimental effects upon its wielder with each strike."
         },
         {
             "name": "Haunted Amulet",
-            "desc": "An innocuous-looking amulet that unwittingly attracts malevolent spirits, potentially subjecting the bearer to eerie encounters.",
+            "desc": "An innocuous-looking amulet that unwittingly attracts malevolent spirits.",
             "rarity": "uncommon",
-            "properties": "Attracts and binds malevolent spirits, leading to eerie and unsettling experiences for the bearer."
+            "properties": "Subjects the bearer to eerie and unsettling experiences."
         },
         {
             "name": "Haunted Mirrors",
-            "desc": "Mirrors that reveal unsettling reflections or transport players to parallel dimensions.",
-            "rarity": "uncommon"
+            "desc": "Eerie-looking mirrors.",
+            "rarity": "uncommon",
+            "properties": "These reveal unsettling reflections or transport players to parallel dimensions. Gaze into them at your own risk, for their otherworldly nature may lead to unexpected and haunting experiences."
         },
         {
             "name": "Mysterious Scroll",
-            "desc": "A cryptic scroll holding unpredictable magical energies, bestowing unexpected outcomes when invoked.",
+            "desc": "A cryptic scroll holding unpredictable magical energies.",
             "rarity": "rare",
-            "properties": "Contains chaotic magical energies that produce unpredictable effects when activated."
+            "properties": "Contains chaotic magical energies that produce unpredictable effects when invoked."
         }
     ],
     "Quest-related Items": [
         {
             "name": "Strange Relic",
-            "desc": "An enigmatic artifact intertwined with an ongoing quest, harboring clues, significance, or a connection to an overarching narrative.",
+            "desc": "An enigmatic artifact, adorned with cryptic symbols and mysterious carvings, its origin and purpose concealed in a veil of intrigue.",
             "rarity": "uncommon",
             "properties": "Connected to a larger quest, holding clues or significance in the unfolding story."
         },
         {
             "name": "Holy Symbol",
-            "desc": "A revered emblem crucial for conducting sacred rituals and engaging in divine interactions, pivotal for devout characters.",
+            "desc": "A sacred emblem, intricately crafted with divine motifs, radiating an aura of reverence.",
             "rarity": "common",
             "properties": "Used as a focus in sacred rituals and to communicate with deities, important to devout characters."
         },
         {
             "name": "Missing Heirloom",
-            "desc": "A sought-after item essential to fulfilling the task of a noble patron or unraveling a complex storyline, bearing relevance to the adventure's trajectory.",
+            "desc": "A treasured item, elegantly crafted and bearing the insignia of noble lineage, its absence shrouded in questions and pivotal to unfolding destinies.",
             "rarity": "rare",
             "properties": "Central to a task or storyline, sought after by patrons or crucial for uncovering secrets in the narrative."
         },
         {
             "name": "Mystic Obelisks",
-            "desc": "Tall, mysterious obelisks that may grant blessings or curses to those who interact with them.",
-            "rarity": "rare"
+            "desc": "Tall, mysterious obelisks.",
+            "rarity": "rare",
+            "properties": "These items may grant blessings or curses to those who interact with them. Approach them with caution, for their effects are unpredictable and may shape the course of your journey."
         },
         {
             "name": "Time-worn Tomes",
-            "desc": "Old books scattered throughout the map, containing forgotten knowledge, spells, or quests for players to discover.",
-            "rarity": "uncommon"
+            "desc": "Old books scattered throughout the map.",
+            "rarity": "uncommon",
+            "properties": "They contain forgotten knowledge, spells, or quests for players to discover. Delve into their pages to unravel the secrets of the past and uncover hidden quests that await your exploration."
         }
     ],
     "Epic and Legendary Items": [
         {
             "name": "Blade of the Archmage",
-            "desc": "A powerful sword that can channel the arcane energy of its wielder, allowing them to cast potent spells and deal extra magical damage with each strike.",
+            "desc": "A gleaming sword adorned with intricate arcane engravings, pulsating with an otherworldly aura.",
             "rarity": "epic",
-            "properties": "Channels wielder's arcane energy, casts spells, and deals extra magical damage."
+            "properties": "Channels wielder's arcane energy, casts spells, and deals extra magical damage with each strike."  
         },
         {
             "name": "Dragonheart Shield",
-            "desc": "A shield crafted from the scale of an ancient dragon, providing resistance to dragon breath attacks and granting the wielder the ability to breathe a cone of elemental energy.",
+            "desc": "A shield crafted from the scale of an ancient dragon.",
             "rarity": "epic",
             "properties": "Resists dragon breath attacks, grants elemental breath ability."
         },
         {
             "name": "Sword of Kas",
-            "desc": "A sentient and malevolent sword once wielded by the lich Vecna's lieutenant, Kas. The blade is capable of slaying gods and granting its wielder immense power.",
+            "desc": "A sentient and malevolent sword once wielded by the lich Vecna's lieutenant, Kas.",
             "rarity": "legendary",
-            "properties": "Grants the wielder the ability to deal tremendous damage and cast powerful spells. It can sever limbs and absorb souls."
+            "properties": "Grants the wielder the ability to deal tremendous damage and cast powerful spells. It can sever limbs and absorb souls. The blade is capable of slaying gods and granting its wielder immense power."
         },
         {
             "name": "Deck of Many Things",
-            "desc": "A deck of cards, each representing a different magical effect. When drawn, the cards can bring about both incredible boons and catastrophic consequences.",
+            "desc": "A deck of cards.",
             "rarity": "legendary",
-            "properties": "Drawing cards from the deck can result in gaining immense wealth, experiencing sudden shifts in alignment, summoning powerful entities, or losing everything."
+            "properties": "Each card represents a different magical effect. Drawing cards from the deck can result in gaining immense wealth, experiencing sudden shifts in alignment, summoning powerful entities, or losing everything."
         },
         {
             "name": "The Hand and Eye of Vecna",
-            "desc": "These are the severed and preserved hand and eye of the powerful lich Vecna. When attached to a character, they grant incredible abilities, but at the cost of corrupting the user.",
+            "desc": "These are the severed and preserved hand and eye of the powerful lich Vecna.",
             "rarity": "legendary",
-            "properties": "The Hand grants immense strength and allows the casting of spells, while the Eye provides clairvoyant abilities and access to powerful magic."
+            "properties": "The Hand grants immense strength and allows the casting of spells, while the Eye provides clairvoyant abilities and access to powerful magic. When attached to a player, they grant incredible abilities, but at the cost of corrupting the user."
         },
         {
             "name": "Talisman of Pure Good and Talisman of Ultimate Evil",
-            "desc": "These are two opposite artifacts, each capable of vanquishing creatures of extreme alignment. The Talisman of Pure Good can obliterate evil beings, and the Talisman of Ultimate Evil can do the same to good beings.",
+            "desc": "These are two opposite artifacts, each capable of vanquishing creatures of extreme alignment.",
             "rarity": "legendary",
-            "properties": "These talismans can be used to unleash a devastating energy blast that eradicates creatures of opposing alignment."
+            "properties": "The Talisman of Pure Good can unleash a devastating energy blast to obliterate evil beings, and the Talisman of Ultimate Evil can do the same to good beings."
         },
         {
             "name": "Staff of the Magi",
-            "desc": "A powerful staff that enhances the spellcasting abilities of its wielder. It also offers protection against magic and the ability to absorb spells.",
+            "desc": "A long, dark staff crafted from ebony wood and adorned with intricate runes.",
             "rarity": "legendary",
             "properties": "Enhances spellcasting abilities, provides spell absorption, and grants various magical protections."
         },
         {
             "name": "Vorpal Sword",
-            "desc": "A blade of legendary power that can instantly sever the head of a creature on a critical hit, killing even the mightiest foes in a single blow.",
+            "desc": "A blade of legendary power that can instantly sever the head of a creature.",
             "rarity": "legendary",
             "properties": "On a critical hit, this sword can instantly slay the target if it fails a saving throw."
         },
         {
             "name": "Ring of Three Wishes",
-            "desc": "A ring that grants its wearer the ability to make three wishes. These wishes can have a wide range of effects, from restoring health to altering reality.",
+            "desc": "A ring that grants its wearer the ability to make three wishes.",
             "rarity": "legendary",
-            "properties": "Allows the user to make three wishes, but the nature of the wishes can have unintended consequences."
+            "properties": "These wishes can have a wide range of effects, from restoring health to altering reality."
         }
     ]    
 }

--- a/item-and-prop-generation/src/metadata/prop_metadata.json
+++ b/item-and-prop-generation/src/metadata/prop_metadata.json
@@ -7,10 +7,10 @@
         "render_rules": {
             "contains_item": false,
             "placement_rules": {
-                "nearWall": "edgeWall",
-                "nearProp": "none",
-                "atCenter": false,
-                "overlap": false
+                "nearWall": "none",
+                "nearProp": "Chair",
+                "atCenter": true,
+                "overlap": true
             },
             "size": { "w": 3, "h": 2 }
         }
@@ -24,9 +24,9 @@
             "contains_item": false,
             "placement_rules": {
                 "nearWall": "none",
-                "nearProp": "none",
+                "nearProp": "Table",
                 "atCenter": false,
-                "overlap": false
+                "overlap": true
             },
             "size": { "w": 1, "h": 1 }
         }
@@ -39,7 +39,7 @@
         "render_rules": {
             "contains_item": false,
             "placement_rules": {
-                "nearWall": "none",
+                "nearWall": "edgeWall",
                 "nearProp": "none",
                 "atCenter": false,
                 "overlap": false
@@ -55,7 +55,7 @@
         "render_rules": {
             "contains_item": false,
             "placement_rules": {
-                "nearWall": "edgeWall",
+                "nearWall": "cornerWall",
                 "nearProp": "none",
                 "atCenter": false,
                 "overlap": false
@@ -78,10 +78,10 @@
                 "Quest-related Items"
             ],
             "placement_rules": {
-                "nearWall": "none",
+                "nearWall": "edgeWall",
                 "nearProp": "none",
                 "atCenter": false,
-                "overlap": false
+                "overlap": true
             },
             "size": { "w": 1, "h": 1 }
         }
@@ -101,7 +101,7 @@
                 "Epic and Legendary Items"
             ],
             "placement_rules": {
-                "nearWall": "none",
+                "nearWall": "edgeWall",
                 "nearProp": "none",
                 "atCenter": false,
                 "overlap": false
@@ -124,8 +124,8 @@
                 "Dungeoneering Supplies"
             ],
             "placement_rules": {
-                "nearWall": "none",
-                "nearProp": "none",
+                "nearWall": "edgeWall",
+                "nearProp": "Bed",
                 "atCenter": false,
                 "overlap": false
             },
@@ -150,7 +150,7 @@
                 "nearWall": "none",
                 "nearProp": "none",
                 "atCenter": false,
-                "overlap": false
+                "overlap": true
             },
             "size": { "w": 2, "h": 2 }
         }
@@ -163,7 +163,7 @@
         "render_rules": {
             "contains_item": false,
             "placement_rules": {
-                "nearWall": "none",
+                "nearWall": "cornerWall",
                 "nearProp": "none",
                 "atCenter": false,
                 "overlap": false
@@ -179,7 +179,7 @@
         "render_rules": {
             "contains_item": false,
             "placement_rules": {
-                "nearWall": "none",
+                "nearWall": "cornerWall",
                 "nearProp": "none",
                 "atCenter": false,
                 "overlap": false
@@ -195,10 +195,10 @@
         "render_rules": {
             "contains_item": false,
             "placement_rules": {
-                "nearWall": "none",
+                "nearWall": "edgeWall",
                 "nearProp": "none",
                 "atCenter": false,
-                "overlap": false
+                "overlap": true
             },
             "size": { "w": 2, "h": 2 }
         }
@@ -211,7 +211,7 @@
         "render_rules": {
             "contains_item": false,
             "placement_rules": {
-                "nearWall": "none",
+                "nearWall": "edgeWall",
                 "nearProp": "none",
                 "atCenter": false,
                 "overlap": false
@@ -227,10 +227,10 @@
         "render_rules": {
             "contains_item": false,
             "placement_rules": {
-                "nearWall": "none",
-                "nearProp": "none",
+                "nearWall": "edgeWall",
+                "nearProp": "Banners",
                 "atCenter": false,
-                "overlap": false
+                "overlap": true
             },
             "size": { "w": 1, "h": 1 }
         }
@@ -243,10 +243,10 @@
         "render_rules": {
             "contains_item": false,
             "placement_rules": {
-                "nearWall": "none",
-                "nearProp": "none",
+                "nearWall": "edgeWall",
+                "nearProp": "Banners",
                 "atCenter": false,
-                "overlap": false
+                "overlap": true
             },
             "size": { "w": 2, "h": 1 }
         }
@@ -275,7 +275,7 @@
         "render_rules": {
             "contains_item": false,
             "placement_rules": {
-                "nearWall": "none",
+                "nearWall": "edgeWall",
                 "nearProp": "none",
                 "atCenter": false,
                 "overlap": false
@@ -285,16 +285,16 @@
     },
     "Statues": {
         "information": {
-            "desc": "Statues covered in dust, which players can clean to reveal hidden passages or items.",
+            "desc": "Statues covered in rubble, which players can clean to reveal hidden passages or items.",
             "rarity": "rare"
         },
         "render_rules": {
             "contains_item": false,
             "placement_rules": {
-                "nearWall": "none",
-                "nearProp": "none",
+                "nearWall": "edgeWall",
+                "nearProp": "Rubble",
                 "atCenter": false,
-                "overlap": false
+                "overlap": true
             },
             "size": { "w": 2, "h": 2 }
         }
@@ -314,7 +314,7 @@
             "placement_rules": {
                 "nearWall": "none",
                 "nearProp": "none",
-                "atCenter": false,
+                "atCenter": true,
                 "overlap": false
             },
             "size": { "w": 2, "h": 1 }
@@ -331,8 +331,8 @@
             "placement_rules": {
                 "nearWall": "none",
                 "nearProp": "none",
-                "atCenter": false,
-                "overlap": false
+                "atCenter": true,
+                "overlap": true
             },
             "size": { "w": 3, "h": 1 }
         }

--- a/item-and-prop-generation/src/metadata/propset_metadata.json
+++ b/item-and-prop-generation/src/metadata/propset_metadata.json
@@ -30,4 +30,5 @@
     "Statuary": {
         "rarity": "rare",
         "props": ["Statues", "Rubble", "Cobwebs"]
+    }
 }

--- a/item-and-prop-generation/src/metadata/propset_metadata.json
+++ b/item-and-prop-generation/src/metadata/propset_metadata.json
@@ -1,20 +1,35 @@
 {
     "Room": {
         "rarity": "common",
-        "props": [
-            "Table", "Chair", "Bed", "Bookshelf"
-        ]
+        "props": ["Table", "Chair", "Bed", "Bookshelf", "Potted Plants", "Cabinet"]
     },
     "Fireplace": {
         "rarity": "rare",
-        "props": [
-            "Fireplace", "Hearth", "Steam Vents", "Candles"
-        ]
+        "props": ["Fireplace", "Chair", "Candles"]
     },
     "Abandoned": {
         "rarity": "uncommon",
-        "props": [
-            "Cobwebs", "Dust", "Runes", "Glyphs"
-        ]
+        "props": ["Cobwebs", "Runes", "Glyphs", "Rubble", "Statues"]
+    },
+    "Storage": {
+        "rarity": "common",
+        "props": ["Barrel", "Cabinet", "Crate", "Jeweled Chest"]
+    },
+    "Library": {
+        "rarity": "common",
+        "props": ["Bookshelf", "Scrolls", "Magical Items", "Table", "Chair"]
+    },
+    "Decoration": {
+        "rarity": "common",
+        "props": ["Banners", "Tapestries", "Candles", "Runes", "Glyphs", "Potted Plants"]
+    },
+    "Treasure Vault": {
+        "rarity": "uncommon",
+        "props": ["Jeweled Chest", "Golden Altar"]
+    },
+    "Statuary": {
+        "rarity": "rare",
+        "props": ["Statues", "Rubble", "Cobwebs"]
     }
+
 }


### PR DESCRIPTION
The prop metadata now contains an attribute that specifies which item category they can hold. It also has a bounding box and placement rules for each prop. The `propset_metadata.json` also has been modified to include more propsets. Lastly, `item_metadata.json` has been modified to change a lot of the items' descriptions and properties, as most of the items had very similar values for their descriptions and properties, causing repetition. Let me know if changes should be be made!