### PR TITLE
Correct the anchor position for multitile props

### DIFF
--- a/webapp/src/renderer/RendererCanvas.jsx
+++ b/webapp/src/renderer/RendererCanvas.jsx
@@ -211,11 +211,13 @@ const RendererCanvas = (props) => {
 	}
 
 	const getProp = (prop) => {
+		let anchorX = 1 / (prop.getSize().w * 2);
+		let anchorY = 1 / (prop.getSize().h * 2);
 		const xPos = (prop.getPosition().getX() + prop.getOffset().getX()) * size;
 		const yPos = (prop.getPosition().getY() + prop.getOffset().getY()) * size;
 
 		let sprite = Sprite.from("resources/props/" + prop.getPathName() + ".png");
-		sprite.anchor.set(0.5);
+		sprite.anchor.set(anchorX, anchorY);
 		sprite.position.set(xPos, yPos);
 		sprite.angle = prop.getRotation();
 		sprite.eventMode = "dynamic";


### PR DESCRIPTION
Props drawn over multiple tiles should now be drawn in the correct position. They do however still overlap.