### PR TITLE
207 generate hallways rooms when mst generation fails

### DIFF
--- a/room-generation/src/hallway/hallwayGenerator.js
+++ b/room-generation/src/hallway/hallwayGenerator.js
@@ -196,11 +196,9 @@ function minimumSpanningTree() {
 
 function mstFailHandler(mst) {
     for (let i = 0; i < rooms.length-1; i++) {
-        let from = rooms[i];
-        let to = rooms[i+1];
         mst.push({
-            from: from,
-            to: to
+            from: i,
+            to: i+1
         });
     }
 }

--- a/room-generation/src/hallway/hallwayGenerator.js
+++ b/room-generation/src/hallway/hallwayGenerator.js
@@ -190,7 +190,19 @@ function minimumSpanningTree() {
             }
         }
     }
-    throw new Error("MST Failed");
+    mstFailHandler(mst);
+    return mst;
+}
+
+function mstFailHandler(mst) {
+    for (let i = 0; i < rooms.length-1; i++) {
+        let from = rooms[i];
+        let to = rooms[i+1];
+        mst.push({
+            from: from,
+            to: to
+        });
+    }
 }
 
 function createHallway(conn) {


### PR DESCRIPTION
When the minimum spanning tree cannot be generated instead of failing and throwing an error, hallways are now generated between each room.

The MST fails when rooms are in a perfectly straight line, or when less than 3 rooms are generated. These cases should now work and have hallways generated between them.